### PR TITLE
Remove -p/d flag from generated webpack command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ Configure `sbt-webpack` and specify Webpack's entry points on `build.sbt`:
 ```
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, SbtWebpack) // Enable the plugin
 
-// The commands that triggers production build (as in `webpack -p`)
-Assets / WebpackKeys.webpack / WebpackKeys.prodCommands := Set("stage")
-
 Assets / WebpackKeys.webpack / WebpackKeys.binary := new File(".") / "node_modules" / ".bin" / "webpack"
 Assets / WebpackKeys.webpack / WebpackKeys.configFile := new File(".") / "webpack.config.js"
 Assets / WebpackKeys.webpack / WebpackKeys.entries := Map(
@@ -101,3 +98,4 @@ Caveats
 --------
 
 * It doesn't work correctly with CSS because CSS dependencies are tracked in Webpack's stats. See: https://github.com/GIVESocialMovement/sbt-vuefy/issues/20
+* In order to diiferentiate the different modes avaliable to you in webpack, You will have to set an environment variable when running `sbt`, i.e. `WEBPACK_ENV=production sbt`. You can then refference that variable in your webpack config.

--- a/src/main/scala/givers/webpack/Compiler.scala
+++ b/src/main/scala/givers/webpack/Compiler.scala
@@ -187,7 +187,6 @@ class Compiler(
     val cmd = Seq(
       binary.getCanonicalPath,
       "--config", prepareWebpackConfig(configFile, filteredEntries, targetDir),
-      if (isProd) { "-p" } else { "-d" }
     ).mkString(" ")
 
     logger.info(cmd)

--- a/src/main/scala/givers/webpack/Compiler.scala
+++ b/src/main/scala/givers/webpack/Compiler.scala
@@ -162,7 +162,6 @@ class ComputeEntryPoints {
 class Compiler(
   binary: File,
   configFile: File,
-  isProd: Boolean,
   baseDir: File,
   targetDir: File,
   logger: ManagedLogger,

--- a/src/main/scala/givers/webpack/SbtWebpack.scala
+++ b/src/main/scala/givers/webpack/SbtWebpack.scala
@@ -19,7 +19,6 @@ object SbtWebpack extends AutoPlugin {
       val configFile = SettingKey[File]("webpackConfigFile", "The location of webpack.config.js")
       val entries = SettingKey[Map[String, Seq[String]]]("webpackEntries", "The entry points as defined here: https://webpack.js.org/concepts/entry-points")
       val nodeModulesPath = TaskKey[File]("webpackNodeModules", "The location of the node_modules.")
-      val prodCommands = TaskKey[Set[String]]("webpackProdCommands", "A set of SBT commands that triggers production build. The default is `stage`. In other words, use -p (as opposed to -d) with webpack.")
     }
   }
 
@@ -31,7 +30,6 @@ object SbtWebpack extends AutoPlugin {
     excludeFilter in webpack := HiddenFileFilter,
     includeFilter in webpack := "*.js",
     nodeModulesPath := new File("./node_modules"),
-    prodCommands in webpack := Set("stage"),
     resourceManaged in webpack := webTarget.value / "webpack" / "main",
     managedResourceDirectories in Assets+= (resourceManaged in webpack in Assets).value,
     resourceGenerators in Assets += webpack in Assets,
@@ -57,9 +55,6 @@ object SbtWebpack extends AutoPlugin {
     val webpackBinaryLocation = (binary in webpack).value
     val webpackConfigFileLocation = (configFile in webpack).value
     val webpackEntryPoints = (entries in webpack).value
-
-    val prodCommandValues = (prodCommands in webpack).value
-    val isProd = state.value.currentCommand.exists { exec => prodCommandValues.contains(exec.commandLine) }
 
     val sources = webpackEntryPoints.values.flatMap { vs => vs.map(baseDir / _) }.toSeq
 
@@ -89,7 +84,6 @@ object SbtWebpack extends AutoPlugin {
       val compiler = new Compiler(
         webpackBinaryLocation,
         webpackConfigFileLocation,
-        isProd,
         baseDir,
         targetDir,
         logger,


### PR DESCRIPTION
Per [this](https://webpack.js.org/api/cli#common-options) note, webpack will use cli options and flags over their config object counterparts.

This plug-in was using the -p/d flags, which are [short-hand](https://webpack.js.org/api/cli#shortcuts) for several options.

*Flag* | *Replaces*
---:|:---
-d | --debug --devtool cheap-module-eval-source-map --output-pathinfo
-p | --optimize-minimize --define process.env.NODE_ENV="production", see [building for production](https://webpack.js.org/guides/production)

It is easier to debug issues with the bundle if all of the configuration was handled in one place. Ideally, that place would be your `webpack.config.js`.

*[EDIT]*
The way this plugin currently works, you could end up running webpack in production mode, with development flags (`NODE_ENV=production sbt run`), and/or running it in development mode (`sbt [stage|dist]`), with production flags.

With the way webpack works, any configurations options set via object that are also set via cli flags will be ignored in favor of the flag values. This can produce some... confusing builds.

This change will allow you run the desired `sbt` command, (`sbt run`, `sbt stage`, etc) with a env variable* that you can use in your config to tell webpack to run in production mode.

`sbt [run|stage|dist]` or `NODE_ENV=production sbt [run|stage|dist]`

**NOTE:** The use of `NODE_ENV=[value]` is arbitrary, and if you want to avoid any collisions with something webpack is setting, feel free to use something else instead.