### PR TITLE
Code-split prep work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ sbt-webpack
 [![Gitter chat](https://badges.gitter.im/GIVE-asia/gitter.png)](https://gitter.im/GIVE-asia/Lobby)
 [ ![Download](https://api.bintray.com/packages/givers/maven/sbt-webpack/images/download.svg) ](https://bintray.com/givers/maven/sbt-webpack/_latestVersion)
 
-`sbt-webpack` integrates [Webpack 4](https://webpack.js.org) with Playframework assets' incremental compilation. 
+`sbt-webpack` integrates [Webpack 4](https://webpack.js.org) with Playframework assets' incremental compilation.
 This plugin also tracks JS dependencies correctly (e.g. using `require` or `import` in a JS file).
 
 You, as a user, are responsible for specifying Webpack's entry points and config files.
 
 `sbt-webpack` is currently used at GIVE.asia. We are using it for packaging [Vue](https://vuejs.org), [Axios](https://github.com/axios/axios), and [Vue-i18](https://github.com/kazupon/vue-i18n) into a single JS file, which is later included in our HTML file. Then, we use [expose-loader](https://github.com/webpack-contrib/expose-loader) to expose the variables `Vue`, `VueI18n`, and `axios`.
- 
+
 Please see a working example in `test-play-project`.
 
 
@@ -24,7 +24,7 @@ Without the plugin, we would have to run `webpack watch` separately and specify 
 
 Playframework already has its own "watch" mechanism and offers a good way to store the compiled JS (so it works with Playfraemework's routing). This plugin integrates Webpack's and Playframework's workflows in a clean way.
 
- 
+
 Requirement
 ------------
 
@@ -32,8 +32,8 @@ Requirement
 * Webpack 4
 * Playframework 2.6
 * Scala 2.12.x and SBT 1.x (because the artifact is only published for this setting)
- 
- 
+
+
 Usage
 ------
 
@@ -58,7 +58,7 @@ Here's a minimal example:
 module.exports = {};
 ```
 
-Please do not specify `entry` here. You will configure `entry` in `build.sbt` instead. 
+Please do not specify `entry` here. You will configure `entry` in `build.sbt` instead.
 
 Please also do not specify `output`. This plugin automatically set `output`, so the generated files can be used by Playframework's routing.
 
@@ -99,4 +99,4 @@ Caveats
 --------
 
 * It doesn't work correctly with CSS because CSS dependencies are tracked in Webpack's stats. See: https://github.com/GIVESocialMovement/sbt-vuefy/issues/20
-* In order to differentiate between development and production, you will have to set an environment variable when running `sbt`, i.e. `NODE_ENV=production sbt`. You can then reference that env variable in your webpack config. See `test-play-project` as an example.
+* In order to diiferentiate the different modes avaliable to you in webpack, You will have to set an environment variable when running `sbt`, i.e. `WEBPACK_ENV=production sbt`. You can then refference that variable in your webpack config.

--- a/src/main/resources/dependency-plugin.js
+++ b/src/main/resources/dependency-plugin.js
@@ -14,6 +14,7 @@ const writeStats = (compilation) => {
     })
   }
 
+  compilation.chunks.map(chunk => ms.push({ name: chunk.id, reasons: '' }));
   const s = JSON.stringify(ms);
 
   compilation.assets['dependency-tree.json'] = {

--- a/src/main/resources/dependency-plugin.js
+++ b/src/main/resources/dependency-plugin.js
@@ -1,10 +1,13 @@
 const writeStats = (compilation) => {
   const ms = [];
+
   for (let module of compilation.getStats().toJson().modules) {
     let reasons = [];
+
     for (let reason of module.reasons) {
       reasons.push(reason.moduleName);
     }
+
     ms.push({
       name: module.name,
       reasons: reasons
@@ -12,6 +15,7 @@ const writeStats = (compilation) => {
   }
 
   const s = JSON.stringify(ms);
+
   compilation.assets['dependency-tree.json'] = {
     source() {
       return s;
@@ -31,3 +35,5 @@ class DependencyPlugin {
 }
 
 module.exports = DependencyPlugin;
+
+

--- a/src/main/resources/dependency-plugin.js
+++ b/src/main/resources/dependency-plugin.js
@@ -14,7 +14,7 @@ const writeStats = (compilation) => {
     })
   }
 
-  compilation.chunks.map(chunk => ms.push({ name: chunk.id, reasons: '' }));
+  compilation.chunks.map(chunk => ms.push({ name: chunk.id, reasons: [''] }));
   const s = JSON.stringify(ms);
 
   compilation.assets['dependency-tree.json'] = {
@@ -36,5 +36,4 @@ class DependencyPlugin {
 }
 
 module.exports = DependencyPlugin;
-
 

--- a/src/main/scala/givers/webpack/Compiler.scala
+++ b/src/main/scala/givers/webpack/Compiler.scala
@@ -111,10 +111,11 @@ class PrepareWebpackConfig {
       )
       webpackConfigFile.write("\n")
       webpackConfigFile.write(s"module.exports.entry = ${Json.prettyPrint(js)};")
+      // add the exension here so that all of the emitted chunks get it
       webpackConfigFile.write(
         s"""
           |module.exports.output = module.exports.output || {};
-          |module.exports.output.filename = module.exports.output.filename || '[name]';
+          |module.exports.output.filename = module.exports.output.filename || '[name].js';
           |module.exports.output.path = '${targetDir.getCanonicalPath.replace("\\","\\\\")}';
           |
           |const DependencyPlugin = require('./dependency-plugin.js');

--- a/test-play-project/app/assets/javascripts/a.js
+++ b/test-play-project/app/assets/javascripts/a.js
@@ -1,6 +1,7 @@
-require('./c.js');
+import $ from 'jquery'
 
-console.log('This is a.js');
+import currentTime from './b';
 
-let test = "variable";
-let arrowFunction = (firstArgument) => { return firstArgument; };
+console.log('The current time is', currentTime);
+
+export default $('.time').html(currentTime);

--- a/test-play-project/app/assets/javascripts/b.js
+++ b/test-play-project/app/assets/javascripts/b.js
@@ -1,3 +1,7 @@
-console.log('This is b.js');
-console.log('This is b.js');
-console.log('This is b.js');
+import moment from 'moment';
+
+console.log('hello from b.js');
+
+const currentTime = moment().format('MMMM Do YYYY, h:mm:ss a');
+
+export default currentTime;

--- a/test-play-project/app/assets/javascripts/c.js
+++ b/test-play-project/app/assets/javascripts/c.js
@@ -1,2 +1,0 @@
-console.log('c');
-console.log('c');

--- a/test-play-project/app/views/index.scala.html
+++ b/test-play-project/app/views/index.scala.html
@@ -1,5 +1,9 @@
 @()
-
-<script src='@routes.Assets.versioned("javascripts/compiled.js")'></script>
-
-<h1>Hello</h1>
+<head>
+  <script src='@routes.Assets.versioned("javascripts/vendor.js")'></script>
+</head>
+<body>
+  <h1>Hello</h1>
+  <p>The current time is <span class="time"></span>.</p>
+  <script src='@routes.Assets.versioned("javascripts/compiled.js")'></script>
+</body>

--- a/test-play-project/build.sbt
+++ b/test-play-project/build.sbt
@@ -18,4 +18,5 @@ Assets / WebpackKeys.webpack / WebpackKeys.binary := {
   }
 }
 Assets / WebpackKeys.webpack / WebpackKeys.configFile := new File(".") / "webpack.config.js"
+// Leave the extension off, it will be added during compilation
 Assets / WebpackKeys.webpack / WebpackKeys.entries := Map("javascripts/compiled" -> Seq("app/assets/javascripts/a.js"))

--- a/test-play-project/build.sbt
+++ b/test-play-project/build.sbt
@@ -18,4 +18,4 @@ Assets / WebpackKeys.webpack / WebpackKeys.binary := {
   }
 }
 Assets / WebpackKeys.webpack / WebpackKeys.configFile := new File(".") / "webpack.config.js"
-Assets / WebpackKeys.webpack / WebpackKeys.entries := Map("javascripts/compiled.js" -> Seq("app/assets/javascripts/a.js"))
+Assets / WebpackKeys.webpack / WebpackKeys.entries := Map("javascripts/compiled" -> Seq("app/assets/javascripts/a.js"))

--- a/test-play-project/build.sbt
+++ b/test-play-project/build.sbt
@@ -18,12 +18,4 @@ Assets / WebpackKeys.webpack / WebpackKeys.binary := {
   }
 }
 Assets / WebpackKeys.webpack / WebpackKeys.configFile := new File(".") / "webpack.config.js"
-Assets / WebpackKeys.webpack / WebpackKeys.entries := Map(
-  "javascripts/a.js" -> Seq("app/assets/javascripts/a.js"),
-  "javascripts/compiled.js" -> Seq(
-    "app/assets/javascripts/b.js",
-    "node_modules/vue/dist/vue.runtime.js",
-    "node_modules/axios/dist/axios.js",
-    "node_modules/vue-i18n/dist/vue-i18n.js",
-  )
-)
+Assets / WebpackKeys.webpack / WebpackKeys.entries := Map("javascripts/compiled.js" -> Seq("app/assets/javascripts/a.js"))

--- a/test-play-project/package.json
+++ b/test-play-project/package.json
@@ -13,6 +13,7 @@
     "@babel/preset-env": "^7.2.3",
     "babel-loader": "^8.0.4",
     "expose-loader": "^0.7.5",
+    "moment-locales-webpack-plugin": "^1.0.7",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2"
   }

--- a/test-play-project/package.json
+++ b/test-play-project/package.json
@@ -1,5 +1,8 @@
 {
-  "dependencies": {},
+  "dependencies": {
+    "jquery": "^3.4.0",
+    "moment": "^2.24.0"
+  },
   "browserslist": [
     "> 1%",
     "last 2 versions",
@@ -8,11 +11,8 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "axios": "^0.18.0",
     "babel-loader": "^8.0.4",
     "expose-loader": "^0.7.5",
-    "vue": "^2.5.21",
-    "vue-i18n": "^8.6.0",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2"
   }

--- a/test-play-project/webpack.config.js
+++ b/test-play-project/webpack.config.js
@@ -1,48 +1,33 @@
-"use strict";
-
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env']
-          }
-        }
-      },
-      {
-        test: /vue\.runtime\.js/,
-        use: {
-          loader: 'expose-loader',
-          options: 'Vue'
-        }
-      },
-      {
-        test: /axios\.js/,
-        use: {
-          loader: 'expose-loader',
-          options: 'axios'
-        }
-      },
-      {
-        test: /vue-i18n\.js/,
-        use: {
-          loader: 'expose-loader',
-          options: 'VueI18n'
+const baseConfig = {
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          chunks: 'initial',
+          name: 'vendor',
+          enforce: true,
         }
       }
-    ],
-  },
-  devtool: ''
+    },
+  }
 };
 
-if (process.env.NODE_ENV === 'production') {
-  console.log('[sbt-webpack] Enable the production mode');
-  module.exports.mode = 'production';
-} else {
-  console.log('[sbt-webpack] Enable the development mode');
-  module.exports.mode = 'development';
+function configFactory(base) {
+  if (process.env.NODE_ENV === 'production') {
+    console.log('[sbt-webpack] Enable the production mode');
+
+    base.mode = 'production';
+  } else {
+    console.log('[sbt-webpack] Enable the development mode');
+
+    base.mode = 'development';
+  }
+
+  return base;
 }
+
+module.exports = configFactory(baseConfig);

--- a/test-play-project/webpack.config.js
+++ b/test-play-project/webpack.config.js
@@ -1,3 +1,5 @@
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
+
 const baseConfig = {
   resolve: {
     extensions: ['.js', '.jsx'],
@@ -13,7 +15,12 @@ const baseConfig = {
         }
       }
     },
-  }
+  },
+  plugins: [
+    new MomentLocalesPlugin({
+      localesToKeep: ['es-us'],
+    }),
+  ],
 };
 
 function configFactory(base) {

--- a/test-play-project/yarn.lock
+++ b/test-play-project/yarn.lock
@@ -848,14 +848,6 @@ atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
-axios@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
-  dependencies:
-    follow-redirects "^1.3.0"
-    is-buffer "^1.1.5"
-
 babel-loader@^8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.4.tgz#7bbf20cbe4560629e2e41534147692d3fecbdce6"
@@ -1275,13 +1267,6 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1588,13 +1573,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
-
-follow-redirects@^1.3.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.6.0.tgz#d12452c031e8c67eb6637d861bfc7a8090167933"
-  integrity sha512-4Oh4eI3S9OueVV41AgJ1oLjpaJUhbJ7JDGOMhe0AFqoSejl5Q2nn3eGglAzRUKVKZE8jG5MNn66TjCJMAnpsWA==
-  dependencies:
-    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -2025,6 +2003,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
+jquery@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
+  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
+
 js-levenshtein@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.4.tgz#3a56e3cbf589ca0081eb22cd9ba0b1290a16d26e"
@@ -2294,6 +2277,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -3371,16 +3359,6 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
-
-vue-i18n@^8.6.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.6.0.tgz#63848b183cf6f100436bcdd84382416e43b07188"
-  integrity sha512-h2zKbspC/yKulfPN1Vp/bewOeFKCRr4tFPDJF+ev/zsSvNs9lORh3Hsq643ELoQJYsUmpWigHkKnRDST6Sz8zw==
-
-vue@^2.5.21:
-  version "2.5.21"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.21.tgz#3d33dcd03bb813912ce894a8303ab553699c4a85"
-  integrity sha512-Aejvyyfhn0zjVeLvXd70h4hrE4zZDx1wfZqia6ekkobLmUZ+vNFQer53B4fu0EjWBSiqApxPejzkO1Znt3joxQ==
 
 watchpack@^1.5.0:
   version "1.6.0"

--- a/test-play-project/yarn.lock
+++ b/test-play-project/yarn.lock
@@ -2119,6 +2119,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash@^4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
@@ -2277,6 +2282,13 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment-locales-webpack-plugin@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.0.7.tgz#ce2931b8a25100dae0868adbd9e93972dcb33359"
+  integrity sha512-KjYpaAhmuzGFZl6534FlZoK7QtW3vqlxd+A17W9DlgHJ5yhXANy7AZJl7iYtZpWjAfMTAWiVrQ7YDZdkFO6uRw==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment@^2.24.0:
   version "2.24.0"


### PR DESCRIPTION
This work showcases how a simple, but typical, webpack config utilizes code splitting.

(To see the code in question working, in `test-play-project/webpack.config.js` comment out the `optimization` block.)

I also cleaned up the main `README.md` a little bit. i.e. removed unneeded whitespace, and fixed a typo or two.