### PR TITLE
Windows Fix

### DIFF
--- a/src/main/scala/givers/webpack/Compiler.scala
+++ b/src/main/scala/givers/webpack/Compiler.scala
@@ -115,7 +115,7 @@ class PrepareWebpackConfig {
         s"""
           |module.exports.output = module.exports.output || {};
           |module.exports.output.filename = module.exports.output.filename || '[name]';
-          |module.exports.output.path = '${targetDir.getCanonicalPath}';
+          |module.exports.output.path = '${targetDir.getCanonicalPath.replace("\\","\\\\")}';
           |
           |const DependencyPlugin = require('./dependency-plugin.js');
           |module.exports.plugins = module.exports.plugins || [];


### PR DESCRIPTION
We decided in the end, to escape all the escaped backslashes returned from `targetDir.getCanonicalPath` found [here](https://github.com/GIVESocialMovement/sbt-webpack/blob/e4b752ff9c382ba49ea15d3938bb9cb111e3f523/src/main/scala/givers/webpack/Compiler.scala#L118).

We also cannot think of any backslashes you would want to let scala escape in the `.getCanonicalPath` only to let the casting to a string ultimately remove in the interpolation, `${targetDir.getCanonicalPath}`.